### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "ttf-utils"
 version = "0.1.3"
+edition = "2021"
 authors = ["Christer Sandberg <chrsan@gmail.com>"]
 keywords = ["ttf", "truetype", "otf", "opentype"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/chrsan/ttf-utils"
 description = "ttf-parser utils"
-readme="README.md"
-edition = "2018"
+readme = "README.md"
+rust-version = "1.78.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ttf-parser = { version = "^0.11", default-features = true }
+ttf-parser = { version = "^0.25", default-features = true }
 
 [dev-dependencies]
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,17 @@ name = "ttf-utils"
 version = "0.1.4"
 edition = "2021"
 authors = ["Christer Sandberg <chrsan@gmail.com>"]
-keywords = ["ttf", "truetype", "otf", "opentype"]
+keywords = ["ttf", "truetype", "otf", "opentype", "font"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/chrsan/ttf-utils"
-description = "ttf-parser utils"
+description = "A crate with embolden, slant, and modify bbox utils for ttf-parser"
 readme = "README.md"
 rust-version = "1.78.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ttf-parser = { version = "^0.25", default-features = true }
+ttf-parser = { version = "0.25", default-features = true }
 
 [dev-dependencies]
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttf-utils"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Christer Sandberg <chrsan@gmail.com>"]
 keywords = ["ttf", "truetype", "otf", "opentype"]

--- a/examples/outline-info.rs
+++ b/examples/outline-info.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 fn main() {
     let opt = Opt::from_args();
     let font_data = std::fs::read(&opt.font_file).unwrap();
-    let face = ttf_parser::Face::from_slice(&font_data, opt.face_index).unwrap();
+    let face = ttf_parser::Face::parse(&font_data, opt.face_index).unwrap();
     let glyph_id = face.glyph_index(opt.character).unwrap();
     let mut outline = ttf_utils::Outline::new(&face, glyph_id).unwrap();
     if opt.embolden {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! `ttf-parser` utils.
+//! `ttf-parser` utils, to embolden, slant, and modify bboxs.
 
 /// A bounding box.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@ impl Outline {
         let mut outline = Outline {
             bbox: std::cell::Cell::new(None),
             // Compact Font Format 1/2
-            cff: face.tables().cff.is_some()
-                || face.tables().cff2.is_some(),
+            cff: face.tables().cff.is_some() || face.tables().cff2.is_some(),
             contours: Vec::new(),
         };
         let mut outline_builder = OutlineBuilder::new(&mut outline);


### PR DESCRIPTION
This patch moves to rust 2021 edition.
It also updates dependencies for use in modern programs:
- ttf-parser 0.11 -> 0.25